### PR TITLE
fix: mypy not able to find subs

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -42,6 +42,7 @@ setup(
             'py.typed',
         ]
     },
+    zip_safe=False,
     test_suite='tests',
     include_package_data=True,
     extras_require={},


### PR DESCRIPTION
https://mypy.readthedocs.io/en/stable/installed_packages.html
```
If you use setuptools, you must pass the option zip_safe=False to setup(), or mypy will not be able to find the installed package.
```