### PR TITLE
fix: remove print statement in __init__.py

### DIFF
--- a/http_exceptions/__init__.py
+++ b/http_exceptions/__init__.py
@@ -8,7 +8,6 @@ except ImportError:
     from importlib_metadata import PackageNotFoundError  # type: ignore[no-redef]
 
 try:
-    print(__name__)
     __version__: str = version(__name__)
 except PackageNotFoundError:
     __version__ = "unknown"


### PR DESCRIPTION
closes https://github.com/DeveloperRSquared/http-exceptions/security/code-scanning/17